### PR TITLE
Replace deprecated function call

### DIFF
--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -36,7 +36,7 @@ def load_and_check_graph(
 ) -> rdflib.Graph:
     graph = rdflib.Graph()
     graph_filepath = os.path.join(os.path.dirname(__file__), basename)
-    graph.load(graph_filepath, format="turtle")
+    graph.parse(graph_filepath, format="turtle")
     conforms = None
     for triple in graph.triples((None, NS_SH.conforms, None)):
         assert conforms is None, "Found second result."
@@ -57,7 +57,7 @@ def load_ontology_graph(
 ) -> rdflib.Graph:
     graph = rdflib.Graph()
     graph_filepath = os.path.join(os.path.dirname(__file__), basename)
-    graph.load(graph_filepath, format="turtle")
+    graph.parse(graph_filepath, format="turtle")
     return graph
 
 def test_coverage():


### PR DESCRIPTION
I'd accidentally used `graph.load()` in a method, which triggered this warning:

    .../rdflib/graph.py:1227: DeprecationWarning: graph.load() is
    deprecated, it will be removed in rdflib 6.0.0. Please use
    graph.parse() instead.

Signed-off-by: Alex Nelson <alexander.nelson@nist.gov>